### PR TITLE
More preconstruct fixes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
+const preconstruct = require('preconstruct');
+
 module.exports = {
   setupFiles: ['./jest-setup.js'],
+  moduleNameMapper: preconstruct.aliases.jest(__dirname),
   testPathIgnorePatterns: ['./cypress/', '__fixtures__'],
   transformIgnorePatterns: ['node_modules/(?!(@atlaskit)/)'],
 };

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     "typescript": "^3.2.1",
     "uglify-js": "^3.1.7",
     "wait-on": "^3.2.0",
-    "webpack": "^4.29.6"
+    "webpack": "^4.29.6",
+    "preconstruct": "^0.0.53"
   },
   "devDependencies": {
     "@atlaskit/build-releases": "^3.0.3",
@@ -148,7 +149,6 @@
     "jest": "^24.1.0",
     "json-loader": "^0.5.7",
     "nodemon": "^1.12.1",
-    "preconstruct": "^0.0.0-typescript.1",
     "prettier": "^1.16.4",
     "react-test-renderer": "^16.0.0",
     "style-loader": "^0.23.0",

--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const path = require('path');
 const withMDX = require('@zeit/next-mdx')({
   extension: /\.mdx?$/,
 });
@@ -37,6 +38,20 @@ module.exports = withCSS(
       config.plugins.push(
         new webpack.ProvidePlugin({ Props: ['pretty-proptypes', 'default'] }),
       );
+
+      // this is only necessary inside the monorepo
+      // outside the monorepo, it will throw, be caught and nothing will happen
+      try {
+        // eslint-disable-next-line no-param-reassign
+        config.resolve.alias = {
+          ...config.resolve.alias,
+          // we're ignoring these linting rules since they _should_ fail
+          // outside the monorepo
+          // eslint-disable-next-line global-require, import/no-extraneous-dependencies
+          ...require('preconstruct').aliases.webpack(path.join(__dirname)),
+        };
+        // eslint-disable-next-line no-empty
+      } catch (err) {}
 
       config.resolve.extensions.push('.tsx', '.ts');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8863,10 +8863,10 @@ postcss@^7.0.0:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-preconstruct@^0.0.0-typescript.1:
-  version "0.0.0-typescript.1"
-  resolved "https://registry.yarnpkg.com/preconstruct/-/preconstruct-0.0.0-typescript.1.tgz#ec16b83a14b39f3a5b38c409d11ba128ba675f36"
-  integrity sha512-hMe8nzaEfqVAohBeEOw0cmp5woIvQHhY3SLICIzINHR0iMS0ehrzI+S7hY9JY92bK76ym44jqDMv/6KQYOenOw==
+preconstruct@^0.0.53:
+  version "0.0.53"
+  resolved "https://registry.yarnpkg.com/preconstruct/-/preconstruct-0.0.53.tgz#9262ed46ba2ba9b70d4698f2a7e4a9a32d716777"
+  integrity sha512-+W/SNZxCrFh7a3iy1Mzfa5oHHrZfUPJ5MX0m71HrzxNzxcthUuNxPP4HtfzoSxMwt/odZBoFmgROla8Fo37j4Q==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.1.2"


### PR DESCRIPTION
- Updates preconstruct to latest which now has the fixes for typescript
- Add aliases to jest and webpack so importing the package will import the source file instead of the dist file