### PR TITLE
Adding decorator support for Examples

### DIFF
--- a/.changeset/8db3f698/changes.json
+++ b/.changeset/8db3f698/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@brisk-docs/website", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/8db3f698/changes.md
+++ b/.changeset/8db3f698/changes.md
@@ -1,0 +1,1 @@
+- Adding the support for decorators for rendering the example pages

--- a/packages/website/src/bin/generate-pages.js
+++ b/packages/website/src/bin/generate-pages.js
@@ -18,6 +18,7 @@ module.exports = async ({
   webpackConfiguration,
   showSubExamples,
   siteName,
+  useDecorator,
 }) => {
   const pagesPath = path.resolve(packageRoot, './pages');
   const componentsPath = path.resolve(
@@ -34,6 +35,7 @@ module.exports = async ({
       useManifests,
       webpackConfiguration,
       showSubExamples,
+      useDecorator,
     },
   );
   const { packages, docs, metaData } = pagesList;

--- a/packages/website/src/bin/page-generator/index.js
+++ b/packages/website/src/bin/page-generator/index.js
@@ -292,6 +292,7 @@ module.exports = async function generatePages(
   const generatorConfig = {
     pagesPath,
     wrappersPath: componentsPath,
+    decoratorPath: options.useDecorator,
   };
 
   const packageSitemap = generatePackagePages(packageInfo, generatorConfig);

--- a/packages/website/src/bin/page-generator/templates/example/index.js
+++ b/packages/website/src/bin/page-generator/templates/example/index.js
@@ -24,4 +24,40 @@ const exampleTemplate = (componentPath, wrapperPath, data = {}) => outdent`
     );
 `;
 
-module.exports = exampleTemplate;
+/**
+ * exampleWithDecoratorTemplate - template for an example page where there is a
+ * decorator also for a wrapped component
+ *
+ * @param {string} componentPath absolute path to the example
+ * @param {string} wrapperPath   absolute path to the page wrapper
+ * @param {object} [data={}]     extra data needed for the page
+ * @param {string} decoratorPath   absolute path to the decorator
+ *
+ * @returns {string} source code for the page
+ */
+const exampleWithDecoratorTemplate = (
+  componentPath,
+  wrapperPath,
+  data = {},
+  decoratorPath,
+) => outdent`
+    import React from 'react';
+    import Component from '${componentPath}';
+    import fileContents from '!!raw-loader!${componentPath}';
+
+    import Wrapper from '${wrapperPath}';
+    import Decorator from '${decoratorPath}';
+    
+     export default () => (
+      <Wrapper data={${JSON.stringify(data)}} fileContents={fileContents}>
+          <Decorator>
+              <Component />
+           </Decorator>   
+      </Wrapper>
+    );
+`;
+
+module.exports = {
+  exampleTemplate,
+  exampleWithDecoratorTemplate,
+};

--- a/packages/website/src/bin/page-generator/templates/example/test.js
+++ b/packages/website/src/bin/page-generator/templates/example/test.js
@@ -1,9 +1,20 @@
 import assertValidTemplate from '../test-utils';
-import exampleTemplate from './index';
+import { exampleTemplate, exampleWithDecoratorTemplate } from './index';
 
 describe('example page template', () => {
-  it('creates valid source code for a page', () => {
+  it('creates valid source code for an example page', () => {
     const source = exampleTemplate('./component/path', './wrapper/path');
+
+    assertValidTemplate(source);
+  });
+
+  it('creates valid source code for an example with decorator page', () => {
+    const source = exampleWithDecoratorTemplate(
+      './component/path',
+      './wrapper/path',
+      {},
+      './decorator/path',
+    );
 
     assertValidTemplate(source);
   });

--- a/packages/website/src/bin/page-generator/templates/index.js
+++ b/packages/website/src/bin/page-generator/templates/index.js
@@ -1,9 +1,11 @@
 const changelogTemplate = require('./changelog');
-const exampleTemplate = require('./example');
+const example = require('./example');
 const singleComponentTemplate = require('./single-component');
 const wrappedComponentTemplate = require('./wrapped-component');
 
 module.exports.changelogTemplate = changelogTemplate;
-module.exports.exampleTemplate = exampleTemplate;
+module.exports.exampleTemplate = example.exampleTemplate;
 module.exports.singleComponentTemplate = singleComponentTemplate;
 module.exports.wrappedComponentTemplate = wrappedComponentTemplate;
+module.exports.exampleWithDecoratorTemplate =
+  example.exampleWithDecoratorTemplate;

--- a/packages/website/src/bin/page-generator/write-pages.integration.test.js
+++ b/packages/website/src/bin/page-generator/write-pages.integration.test.js
@@ -68,6 +68,21 @@ describe('Page templates', () => {
     assertNoAbsoluteImports(outputRaw);
   });
 
+  it('creates decorators for example pages when there is a decorator path provided', () => {
+    const decoratorPath = path.join(cwd, 'decorators');
+    generators.generateExamplePage(
+      'output.js',
+      'output-raw.js',
+      path.join(cwd, 'example.js'),
+      {},
+      { wrappersPath, pagesPath, decoratorPath },
+    );
+
+    const output = getOutput('output.js');
+
+    expect(output).toMatch(/^import Decorator from /m);
+  });
+
   it('creates js for a docs home page', () => {
     generators.generateDocsHomePage(
       'output.js',

--- a/packages/website/src/bin/page-generator/write-pages.js
+++ b/packages/website/src/bin/page-generator/write-pages.js
@@ -6,6 +6,7 @@ const {
   exampleTemplate,
   singleComponentTemplate,
   wrappedComponentTemplate,
+  exampleWithDecoratorTemplate,
 } = require('./templates');
 
 const writeFile = (pagePath, content) => {
@@ -29,6 +30,7 @@ const getGenericPageInfo = (
   componentPath,
   wrappersPath,
   wrapperName,
+  decoratorPath,
 ) => {
   const absolutePagePath = path.resolve(pagesPath, pagePath);
   const componentImportPath = componentPath
@@ -38,11 +40,16 @@ const getGenericPageInfo = (
     absolutePagePath,
     path.join(wrappersPath, `${wrapperName}.js`),
   );
+  const decoratorImportPath =
+    decoratorPath && decoratorPath.length > 0
+      ? getImportPath(absolutePagePath, decoratorPath)
+      : undefined;
 
   return {
     absolutePagePath,
     componentImportPath,
     packageHomeWrapperPath,
+    decoratorImportPath,
   };
 };
 
@@ -161,21 +168,33 @@ const generateExamplePage = (
 ) => {
   const componentPath = exampleModulePath;
   const wrapperName = 'package-example';
-  const { wrappersPath, pagesPath } = config;
+  const { wrappersPath, pagesPath, decoratorPath } = config;
 
-  const { componentImportPath, packageHomeWrapperPath } = getGenericPageInfo(
+  const {
+    componentImportPath,
+    packageHomeWrapperPath,
+    decoratorImportPath,
+  } = getGenericPageInfo(
     pagesPath,
     pagePath,
     componentPath,
     wrappersPath,
     wrapperName,
+    decoratorPath,
   );
 
   const pageData = { ...data, pageTitle: title };
 
   writeFile(
     path.join(pagesPath, pagePath),
-    exampleTemplate(componentImportPath, packageHomeWrapperPath, pageData),
+    decoratorImportPath
+      ? exampleWithDecoratorTemplate(
+          componentImportPath,
+          packageHomeWrapperPath,
+          pageData,
+          decoratorImportPath,
+        )
+      : exampleTemplate(componentImportPath, packageHomeWrapperPath, pageData),
   );
 
   writeFile(


### PR DESCRIPTION
Here we support the Consumer app to have a file which exports default the decorator and specify the filepath in the docs.config.js. Then we read the file and wraps the examples inside the decorator.